### PR TITLE
[EAGLE-5211] Refract openai whisper example

### DIFF
--- a/models/model_upload/speech-recognition/openai-whisper/1/model.py
+++ b/models/model_upload/speech-recognition/openai-whisper/1/model.py
@@ -1,13 +1,15 @@
-import copy
 import io
+import itertools
+import wave
 from typing import Iterator
 
-import requests
+from clarifai.runners.models.model_runner import ModelRunner
 from clarifai_grpc.grpc.api import resources_pb2, service_pb2
-from clarifai_grpc.grpc.api.status import status_code_pb2, status_pb2
+from clarifai_grpc.grpc.api.status import status_code_pb2
+from google.protobuf import json_format
 from openai import OpenAI
 
-from clarifai.runners.models.model_runner import ModelRunner
+OPENAI_API_KEY = "OPENAI_API_KEY"
 
 
 def bytes_to_audio_file(audio_bytes):
@@ -15,57 +17,68 @@ def bytes_to_audio_file(audio_bytes):
   if not audio_bytes:
     raise ValueError("Audio bytes cannot be empty.")
   audio_file = io.BytesIO(audio_bytes)
-  audio_file.name = "audio.mp3"  # This name is used for the API
+  audio_file.name = "audio.wav"  # This name is used for the API
   return audio_file
 
 
-def preprocess_audio(audio_url=None, audio_bytes=None, chunk_size=1024, stream=False):
+def preprocess_audio(audio_bytes=None, chunk_duration=1.0, stream=False):
   """
   Fetch and preprocess audio data from a URL or bytes.
 
   Parameters:
-    url (str): URL to fetch audio from (if provided).
     bytes (bytes): Audio data in bytes (if provided).
-    chunk_size (int): Size of chunks for streaming.
+    chunk_duration (float): Duration of each audio chunk in seconds.
     stream (bool): Whether to stream the audio in chunks.
 
   Returns:
-    Generator or file-like object containing audio data.
+    Audio data in bytes or a generator of audio chunks.
   """
 
   if audio_bytes:
     if stream:
-      # Stream the audio in chunks (generator)
-      def audio_stream_generator():
-        for i in range(0, len(audio_bytes), chunk_size):
-          yield audio_bytes[i : i + chunk_size]
+      # Read the original audio bytes
+      audio_bytes = io.BytesIO(audio_bytes)
+      with wave.open(audio_bytes, "rb") as wave_file:
+        params = wave_file.getparams()
+        sample_rate = params.framerate
+        channels = params.nchannels
+        sample_width = params.sampwidth
 
-      return audio_stream_generator()
+        # Calculate number of frames per chunk
+        frames_per_chunk = int(sample_rate * chunk_duration)
+
+        # Stream the audio in chunks (generator)
+        def audio_stream_generator():
+          while True:
+            frames = wave_file.readframes(frames_per_chunk)
+            if not frames:
+              break
+            chunk_buffer = io.BytesIO()
+            with wave.open(chunk_buffer, "wb") as chunk_wav:
+              chunk_wav.setnchannels(channels)
+              chunk_wav.setsampwidth(sample_width)
+              chunk_wav.setframerate(sample_rate)
+              chunk_wav.writeframes(frames)
+            yield chunk_buffer.getvalue()
+
+        return audio_stream_generator()
     else:
       # Return a single chunk of audio
       return audio_bytes
-  elif audio_url:
-    response = requests.get(audio_url, stream=stream)
-    if response.status_code != 200:
-      raise Exception(f"Failed to fetch audio. Status code: {response.status_code}")
-
-    if stream:
-      # Stream the audio in chunks (generator)
-      def audio_stream_generator():
-        for chunk in response.iter_content(chunk_size=chunk_size):
-          if chunk:  # Filter out keep-alive new chunks
-            yield chunk
-
-      return audio_stream_generator()
-    else:
-      # Return a single chunk of audio
-      return response.content
-
   else:
-    raise ValueError("Either 'url' or 'audio_bytes' must be provided")
+    raise ValueError("'audio_bytes' must be provided")
 
 
-OPENAI_API_KEY = "API_KEY"
+def get_inference_params(request) -> dict:
+  """Get the inference params from the request."""
+  inference_params = {}
+  if request.model.model_version.id != "":
+    output_info = request.model.model_version.output_info
+    output_info = json_format.MessageToDict(output_info, preserving_proto_field_name=True)
+
+    if "params" in output_info:
+      inference_params = output_info["params"]
+  return inference_params
 
 
 class MyRunner(ModelRunner):
@@ -74,106 +87,76 @@ class MyRunner(ModelRunner):
   def load_model(self):
     """Load the model here."""
     self.client = OpenAI(api_key=OPENAI_API_KEY)
-    self.modelname = "whisper-1"
-    self.language = None
+    self.model = "whisper-1"
 
-    # reset the task in set_translate_task
-    self.task = "transcribe"
-
-  def predict(
-    self, request: service_pb2.PostModelOutputsRequest
-  ) -> service_pb2.MultiOutputResponse:
-    """This is the method that will be called when the runner is run. It takes in an input and
-    returns an output.
-    """
-
+  def predict(self,
+              request: service_pb2.PostModelOutputsRequest) -> service_pb2.MultiOutputResponse:
+    """Predict the output for the given audio data."""
+    inference_params = get_inference_params(request)
+    language = inference_params.get("language", None)
+    task = inference_params.get("task", "transcription")
     outputs = []
     # TODO: parallelize this over inputs in a single request.
-    for inp in request.inputs:
+    for input in request.inputs:
       output = resources_pb2.Output()
 
-      data = inp.data
-      audio_bytes = None
-      if data.audio.base64:
-        audio_bytes = preprocess_audio(audio_bytes=data.audio.base64, stream=False)
+      input_data = input.data
+      audio_bytes = preprocess_audio(audio_bytes=input_data.audio.base64, stream=False)
 
-      elif data.audio.url:
-        audio_bytes = preprocess_audio(
-          audio_url=data.audio.url,
-          stream=False,
-        )
-
-      # Send audio bytes to Whisper for transcription
-      transcription = self.client.audio.transcriptions.create(
-        model=self.modelname, language=self.language, file=bytes_to_audio_file(audio_bytes)
-      )
+      if task == "transcription":
+        # Send audio bytes to Whisper for transcription
+        whisper_output = self.client.audio.transcriptions.create(
+            model=self.model, language=language, file=bytes_to_audio_file(audio_bytes))
+      elif task == "translation":
+        # Send audio bytes to Whisper for translation
+        whisper_output = self.client.audio.translations.create(
+            model=self.model, file=bytes_to_audio_file(audio_bytes))
 
       # Set the output data
-      output.data.text.raw = transcription.text
+      output.data.text.raw = whisper_output.text
       output.status.code = status_code_pb2.SUCCESS
       outputs.append(output)
-    return service_pb2.MultiOutputResponse(
-      outputs=outputs,
-    )
+    return service_pb2.MultiOutputResponse(outputs=outputs,)
 
-  def generate(
-    self, request: service_pb2.PostModelOutputsRequest
-  ) -> Iterator[service_pb2.MultiOutputResponse]:
-    def request_iterator(request, chunk_size=1024):
-      request_copy = copy.deepcopy(request)
-      for inp in request_copy.inputs:
-        data = inp.data
+  def generate(self, request: service_pb2.PostModelOutputsRequest
+              ) -> Iterator[service_pb2.MultiOutputResponse]:
+    """Generate the output in a streaming fashion for large audio files."""
+    inference_params = get_inference_params(request)
+    language = inference_params.get("language", None)
+    task = inference_params.get("task", "transcription")
+    batch_audio_streams = []
+    for input in request.inputs:
+      output = resources_pb2.Output()
 
-        audio_chunks = None
-        if data.audio.base64:
-          audio_chunks = preprocess_audio(
-            audio_bytes=data.audio.base64, stream=True, chunk_size=chunk_size
-          )
-        elif data.audio.url:
-          audio_chunks = preprocess_audio(
-            audio_url=data.audio.url,
-            stream=True,
-            chunk_size=chunk_size,
-          )
+      input_data = input.data
 
-        for chunk in audio_chunks:
-          inp.data.audio.base64 = chunk
-          yield request_copy
+      audio_bytes = input_data.audio.base64
+      chunk_duration = 3.0
 
-    chunk_size = 1024 * 1024
-    return self.stream(request_iterator(request, chunk_size=chunk_size))
+      audio_stream = preprocess_audio(
+          audio_bytes=audio_bytes, stream=True, chunk_duration=chunk_duration)
+      batch_audio_streams.append(audio_stream)
 
-  def stream(
-    self, request_iterator: Iterator[service_pb2.PostModelOutputsRequest]
-  ) -> Iterator[service_pb2.MultiOutputResponse]:
+    for audio_stream in itertools.zip_longest(*batch_audio_streams, fillvalue=None):
+      resp = service_pb2.MultiOutputResponse()
+
+      for audio_bytes in audio_stream:
+        output = resp.outputs.add()
+        if task == "transcription":
+          # Send audio bytes to Whisper for transcription
+          whisper_output = self.client.audio.transcriptions.create(
+              model=self.model, language=language, file=bytes_to_audio_file(audio_bytes))
+        elif task == "translation":
+          # Send audio bytes to Whisper for translation
+          whisper_output = self.client.audio.translations.create(
+              model=self.model, file=bytes_to_audio_file(audio_bytes))
+        output.data.text.raw = whisper_output.text
+        output.status.code = status_code_pb2.SUCCESS
+      yield resp
+
+  def stream(self, request_iterator: Iterator[service_pb2.PostModelOutputsRequest]
+            ) -> Iterator[service_pb2.MultiOutputResponse]:
+    """Stream the output in a streaming fashion"""
     for request in request_iterator:
-      for inp in request.inputs:
-        output = resources_pb2.Output()
-
-        data = inp.data
-        chunk_size = 10 * 1024 * 1024
-        if data.image.base64 != b"":
-          audio_chunks = preprocess_audio(
-            audio_bytes=data.audio.base64, stream=True, chunk_size=chunk_size
-          )
-        elif data.audio.url != "":
-          audio_chunks = preprocess_audio(
-            audio_url=data.audio.url, stream=True, chunk_size=chunk_size
-          )
-
-        for chunk in audio_chunks:
-          transcription = self.client.audio.transcriptions.create(
-            model=self.modelname, language=self.language, file=bytes_to_audio_file(chunk)
-          )
-          # Set the output data
-          output.data.text.raw = transcription.text
-
-          output.status.code = status_code_pb2.SUCCESS
-          result = service_pb2.MultiOutputResponse(
-            status=status_pb2.Status(
-              code=status_code_pb2.SUCCESS,
-              description="Success",
-            ),
-            outputs=[output],
-          )
-          yield result
+      for response in self.generate(request):
+        yield response

--- a/models/model_upload/speech-recognition/openai-whisper/requirements.txt
+++ b/models/model_upload/speech-recognition/openai-whisper/requirements.txt
@@ -1,2 +1,2 @@
-openai
+openai==1.55.3
 requests


### PR DESCRIPTION
### What

- Implemented stream generation of the output text from any audio files in the `generate` method i.e it will transcribe the the audio file in the stream way even though openai whisper API don't support streaming
- corrected both `generate` and `stream` methods for batch requests
- Refracted Openai whisper example, now the `model.py` code is more readable

#### How
We got the input audio in bytes, first split the original audio into chunks of audios,  Each chunk is a valid WAV file with proper headers, allowing them to be processed independently, then run the whisper API for each audio WAV file also ensuring that batch requests also supported.

### Test
Tested this model example locally using local dev runner
