### PR TITLE
[EAGLE-5211] Implement support for Video streaming and Refract Image Models

### DIFF
--- a/models/model_upload/image-classifier/nsfw-image-classifier/1/model.py
+++ b/models/model_upload/image-classifier/nsfw-image-classifier/1/model.py
@@ -1,7 +1,9 @@
 import os
+import tempfile
 from io import BytesIO
 from typing import Iterator
 
+import cv2
 import torch
 from clarifai.runners.models.model_runner import ModelRunner
 from clarifai.utils.logging import logger
@@ -14,6 +16,33 @@ from transformers import AutoModelForImageClassification, ViTImageProcessor
 def preprocess_image(image_bytes):
   """Fetch and preprocess image data from bytes"""
   return Image.open(BytesIO(image_bytes)).convert("RGB")
+
+
+def video_to_frames(video_bytes):
+  """Convert video bytes to frames"""
+  # Write video bytes to a temporary file
+  with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as temp_video_file:
+    temp_video_file.write(video_bytes)
+    temp_video_path = temp_video_file.name
+
+  video = cv2.VideoCapture(temp_video_path)
+  print("video opened")
+  logger.info(f"video opened: {video.isOpened()}")
+  while video.isOpened():
+    ret, frame = video.read()
+    if not ret:
+      break
+    # Convert the frame to byte format
+    frame_bytes = cv2.imencode('.jpg', frame)[1].tobytes()
+    yield frame_bytes
+
+
+def classify_image(images, model, processor, device):
+  """Classify an image using the model and processor."""
+  inputs = processor(images=images, return_tensors="pt")
+  inputs = {name: tensor.to(device) for name, tensor in inputs.items()}
+  logits = model(**inputs).logits
+  return logits
 
 
 class MyRunner(ModelRunner):
@@ -39,9 +68,6 @@ class MyRunner(ModelRunner):
     returns an output.
     """
 
-    # Get the concept protos from the model.
-    concept_protos = request.model.model_version.output_info.data.concepts
-
     outputs = []
     images = []
     for input in request.inputs:
@@ -50,17 +76,19 @@ class MyRunner(ModelRunner):
       images.append(image)
 
     with torch.no_grad():
-      inputs = self.processor(images=images, return_tensors="pt")
-      inputs = {name: tensor.to(self.device) for name, tensor in inputs.items()}
-      logits = self.model(**inputs).logits
+      logits = classify_image(images, self.model, self.processor, self.device)
 
       for logit in logits:
         output_concepts = []
         probs = torch.softmax(logit, dim=-1)
         sorted_indices = torch.argsort(probs, dim=-1, descending=True)
         for idx in sorted_indices:
-          concept_protos[idx.item()].value = probs[idx.item()].item()
-          output_concepts.append(concept_protos[idx.item()])
+          output_concepts.append(
+              resources_pb2.Concept(
+                  id=str(idx.item()),
+                  name=str(idx.item()),
+                  value=probs[idx].item(),
+              ))
 
         output = resources_pb2.Output()
         output.data.concepts.extend(output_concepts)
@@ -71,9 +99,70 @@ class MyRunner(ModelRunner):
 
   def generate(self, request: service_pb2.PostModelOutputsRequest
               ) -> Iterator[service_pb2.MultiOutputResponse]:
-    raise NotImplementedError("Stream method is not implemented for image classification models.")
+
+    if len(request.inputs) != 1:
+      raise ValueError("Only one input is allowed for image classification models.")
+    for input in request.inputs:
+      input_data = input.data
+
+      if input_data.video.base64:
+        video_bytes = input_data.video.base64
+      elif input_data.image.base64:
+        logger.info("Image input")
+        logger.info(
+            f"len(input_data.image.base64): {len(input_data.image.base64)} start of image: {input_data.image.base64[:10]}"
+        )
+        video_bytes = input_data.image.base64
+
+      frame_generator = video_to_frames(video_bytes)
+      for frame in frame_generator:
+        image = preprocess_image(frame)
+        images = [image]
+
+        with torch.no_grad():
+          logits = classify_image(images, self.model, self.processor, self.device)
+
+          for logit in logits:
+            output_concepts = []
+            probs = torch.softmax(logit, dim=-1)
+            sorted_indices = torch.argsort(probs, dim=-1, descending=True)
+            for idx in sorted_indices:
+              output_concepts.append(
+                  resources_pb2.Concept(
+                      id=str(idx.item()),
+                      name=str(idx.item()),
+                      value=probs[idx].item(),
+                  ))
+
+            output = resources_pb2.Output()
+            output.data.image.base64 = frame
+            output.data.concepts.extend(output_concepts)
+            output.status.code = status_code_pb2.SUCCESS
+            yield service_pb2.MultiOutputResponse(outputs=[
+                output,
+            ])
 
   def stream(self, request_iterator: Iterator[service_pb2.PostModelOutputsRequest]
             ) -> Iterator[service_pb2.MultiOutputResponse]:
-    ## raise NotImplementedError
-    raise NotImplementedError("Stream method is not implemented for image classification models.")
+    for request in request_iterator:
+      for output in self.generate(request):
+        yield output
+
+
+if __name__ == '__main__':
+  # Make sure you set these env vars before running the example.
+  # CLARIFAI_PAT
+  # CLARIFAI_USER_ID
+  # CLARIFAI_API_BASE
+  # CLARIFAI_RUNNER_ID
+  # CLARIFAI_NODEPOOL_ID
+  # CLARIFAI_COMPUTE_CLUSTER_ID
+
+  # You need to first create a runner in the Clarifai API and then use the ID here.
+  MyRunner(
+      runner_id=os.environ["CLARIFAI_RUNNER_ID"],
+      nodepool_id=os.environ["CLARIFAI_NODEPOOL_ID"],
+      compute_cluster_id=os.environ["CLARIFAI_COMPUTE_CLUSTER_ID"],
+      base_url=os.environ["CLARIFAI_API_BASE"],
+      num_parallel_polls=int(os.environ.get("CLARIFAI_NUM_THREADS", 1)),
+  ).start()

--- a/models/model_upload/image-classifier/nsfw-image-classifier/1/model.py
+++ b/models/model_upload/image-classifier/nsfw-image-classifier/1/model.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 from io import BytesIO
@@ -8,7 +9,7 @@ import torch
 from clarifai.runners.models.model_runner import ModelRunner
 from clarifai.utils.logging import logger
 from clarifai_grpc.grpc.api import resources_pb2, service_pb2
-from clarifai_grpc.grpc.api.status import status_code_pb2
+from clarifai_grpc.grpc.api.status import status_code_pb2, status_pb2
 from PIL import Image
 from transformers import AutoModelForImageClassification, ViTImageProcessor
 
@@ -24,17 +25,19 @@ def video_to_frames(video_bytes):
   with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as temp_video_file:
     temp_video_file.write(video_bytes)
     temp_video_path = temp_video_file.name
+    logger.info(f"temp_video_path: {temp_video_path}")
 
-  video = cv2.VideoCapture(temp_video_path)
-  print("video opened")
-  logger.info(f"video opened: {video.isOpened()}")
-  while video.isOpened():
-    ret, frame = video.read()
-    if not ret:
-      break
-    # Convert the frame to byte format
-    frame_bytes = cv2.imencode('.jpg', frame)[1].tobytes()
-    yield frame_bytes
+    video = cv2.VideoCapture(temp_video_path)
+    print("video opened")
+    logger.info(f"video opened: {video.isOpened()}")
+    while video.isOpened():
+      ret, frame = video.read()
+      if not ret:
+        break
+      # Convert the frame to byte format
+      frame_bytes = cv2.imencode('.jpg', frame)[1].tobytes()
+      yield frame_bytes
+    video.release()
 
 
 def classify_image(images, model, processor, device):
@@ -43,6 +46,28 @@ def classify_image(images, model, processor, device):
   inputs = {name: tensor.to(device) for name, tensor in inputs.items()}
   logits = model(**inputs).logits
   return logits
+
+
+def process_concepts(logits, images, labels):
+  """Process the logits and return the concepts."""
+  outputs = []
+  for i, logit in enumerate(logits):
+    output_concepts = []
+    probs = torch.softmax(logit, dim=-1)
+    sorted_indices = torch.argsort(probs, dim=-1, descending=True)
+    for idx in sorted_indices:
+      output_concepts.append(
+          resources_pb2.Concept(
+              id=str(idx.item()),
+              name=labels[str(idx.item())],
+              value=probs[idx].item(),
+          ))
+    output = resources_pb2.Output()
+    output.data.image.base64 = images[i].tobytes()
+    output.data.concepts.extend(output_concepts)
+    output.status.code = status_code_pb2.SUCCESS
+    outputs.append(output)
+  return outputs
 
 
 class MyRunner(ModelRunner):
@@ -60,6 +85,11 @@ class MyRunner(ModelRunner):
 
     self.model = AutoModelForImageClassification.from_pretrained(checkpoint_path,).to(self.device)
     self.processor = ViTImageProcessor.from_pretrained(checkpoint_path)
+    config_path = os.path.join(checkpoint_path, 'config.json')
+    with open(config_path, 'r') as f:
+      config = json.load(f)
+
+    self.labels = config['id2label']
     logger.info("Done loading!")
 
   def predict(self, request: service_pb2.PostModelOutputsRequest
@@ -77,72 +107,40 @@ class MyRunner(ModelRunner):
 
     with torch.no_grad():
       logits = classify_image(images, self.model, self.processor, self.device)
+      outputs = process_concepts(logits, images, self.labels)
 
-      for logit in logits:
-        output_concepts = []
-        probs = torch.softmax(logit, dim=-1)
-        sorted_indices = torch.argsort(probs, dim=-1, descending=True)
-        for idx in sorted_indices:
-          output_concepts.append(
-              resources_pb2.Concept(
-                  id=str(idx.item()),
-                  name=str(idx.item()),
-                  value=probs[idx].item(),
-              ))
-
-        output = resources_pb2.Output()
-        output.data.concepts.extend(output_concepts)
-        output.status.code = status_code_pb2.SUCCESS
-        outputs.append(output)
-
-    return service_pb2.MultiOutputResponse(outputs=outputs,)
+    return service_pb2.MultiOutputResponse(
+        outputs=outputs, status=status_pb2.Status(code=status_code_pb2.SUCCESS))
 
   def generate(self, request: service_pb2.PostModelOutputsRequest
               ) -> Iterator[service_pb2.MultiOutputResponse]:
 
     if len(request.inputs) != 1:
-      raise ValueError("Only one input is allowed for image classification models.")
+      raise ValueError("Only one input is allowed for image models for this method.")
     for input in request.inputs:
       input_data = input.data
-
+      video_bytes = None
       if input_data.video.base64:
         video_bytes = input_data.video.base64
-      elif input_data.image.base64:
-        logger.info("Image input")
-        logger.info(
-            f"len(input_data.image.base64): {len(input_data.image.base64)} start of image: {input_data.image.base64[:10]}"
-        )
-        video_bytes = input_data.image.base64
+      if video_bytes:
+        frame_generator = video_to_frames(video_bytes)
+        for frame in frame_generator:
+          image = preprocess_image(frame)
+          images = [image]
 
-      frame_generator = video_to_frames(video_bytes)
-      for frame in frame_generator:
-        image = preprocess_image(frame)
-        images = [image]
-
-        with torch.no_grad():
-          logits = classify_image(images, self.model, self.processor, self.device)
-
-          for logit in logits:
-            output_concepts = []
-            probs = torch.softmax(logit, dim=-1)
-            sorted_indices = torch.argsort(probs, dim=-1, descending=True)
-            for idx in sorted_indices:
-              output_concepts.append(
-                  resources_pb2.Concept(
-                      id=str(idx.item()),
-                      name=str(idx.item()),
-                      value=probs[idx].item(),
-                  ))
-            output = resources_pb2.Output()
-            output.data.image.base64 = frame
-            output.data.concepts.extend(output_concepts)
-            output.status.code = status_code_pb2.SUCCESS
-            yield service_pb2.MultiOutputResponse(outputs=[
-                output,
-            ])
+          with torch.no_grad():
+            logits = classify_image(images, self.model, self.processor, self.device)
+            outputs = process_concepts(logits, images, self.labels)
+            yield service_pb2.MultiOutputResponse(
+                outputs=outputs, status=status_pb2.Status(code=status_code_pb2.SUCCESS))
+      else:
+        raise ValueError("Only video input is allowed for this method.")
 
   def stream(self, request_iterator: Iterator[service_pb2.PostModelOutputsRequest]
             ) -> Iterator[service_pb2.MultiOutputResponse]:
     for request in request_iterator:
-      for output in self.generate(request):
-        yield output
+      if request.inputs[0].data.video.base64:
+        for output in self.generate(request):
+          yield output
+      elif request.inputs[0].data.image.base64:
+        yield self.predict(request)

--- a/models/model_upload/image-classifier/nsfw-image-classifier/1/model.py
+++ b/models/model_upload/image-classifier/nsfw-image-classifier/1/model.py
@@ -133,7 +133,6 @@ class MyRunner(ModelRunner):
                       name=str(idx.item()),
                       value=probs[idx].item(),
                   ))
-
             output = resources_pb2.Output()
             output.data.image.base64 = frame
             output.data.concepts.extend(output_concepts)
@@ -147,22 +146,3 @@ class MyRunner(ModelRunner):
     for request in request_iterator:
       for output in self.generate(request):
         yield output
-
-
-if __name__ == '__main__':
-  # Make sure you set these env vars before running the example.
-  # CLARIFAI_PAT
-  # CLARIFAI_USER_ID
-  # CLARIFAI_API_BASE
-  # CLARIFAI_RUNNER_ID
-  # CLARIFAI_NODEPOOL_ID
-  # CLARIFAI_COMPUTE_CLUSTER_ID
-
-  # You need to first create a runner in the Clarifai API and then use the ID here.
-  MyRunner(
-      runner_id=os.environ["CLARIFAI_RUNNER_ID"],
-      nodepool_id=os.environ["CLARIFAI_NODEPOOL_ID"],
-      compute_cluster_id=os.environ["CLARIFAI_COMPUTE_CLUSTER_ID"],
-      base_url=os.environ["CLARIFAI_API_BASE"],
-      num_parallel_polls=int(os.environ.get("CLARIFAI_NUM_THREADS", 1)),
-  ).start()

--- a/models/model_upload/image-classifier/nsfw-image-classifier/requirements.txt
+++ b/models/model_upload/image-classifier/nsfw-image-classifier/requirements.txt
@@ -3,6 +3,6 @@ tokenizers==0.19.1
 transformers==4.44.1
 pillow==10.4.0
 requests==2.32.3
-opencv-python==4.10.0.84
+opencv-python-headless==4.10.0.84
 aiohttp
 numpy

--- a/models/model_upload/image-classifier/nsfw-image-classifier/requirements.txt
+++ b/models/model_upload/image-classifier/nsfw-image-classifier/requirements.txt
@@ -3,3 +3,6 @@ tokenizers==0.19.1
 transformers==4.44.1
 pillow==10.4.0
 requests==2.32.3
+opencv-python==4.10.0.84
+aiohttp
+numpy

--- a/models/model_upload/image-detector/detr-resnet-image-detection/1/model.py
+++ b/models/model_upload/image-detector/detr-resnet-image-detection/1/model.py
@@ -150,22 +150,3 @@ class MyRunner(ModelRunner):
     for request in request_iterator:
       for output in self.generate(request):
         yield output
-
-
-if __name__ == '__main__':
-  # Make sure you set these env vars before running the example.
-  # CLARIFAI_PAT
-  # CLARIFAI_USER_ID
-  # CLARIFAI_API_BASE
-  # CLARIFAI_RUNNER_ID
-  # CLARIFAI_NODEPOOL_ID
-  # CLARIFAI_COMPUTE_CLUSTER_ID
-
-  # You need to first create a runner in the Clarifai API and then use the ID here.
-  MyRunner(
-      runner_id=os.environ["CLARIFAI_RUNNER_ID"],
-      nodepool_id=os.environ["CLARIFAI_NODEPOOL_ID"],
-      compute_cluster_id=os.environ["CLARIFAI_COMPUTE_CLUSTER_ID"],
-      base_url=os.environ["CLARIFAI_API_BASE"],
-      num_parallel_polls=int(os.environ.get("CLARIFAI_NUM_THREADS", 1)),
-  ).start()

--- a/models/model_upload/image-detector/detr-resnet-image-detection/1/model.py
+++ b/models/model_upload/image-detector/detr-resnet-image-detection/1/model.py
@@ -1,10 +1,12 @@
 import os
+import tempfile
 from io import BytesIO
 from typing import Iterator
 
-import requests
+import cv2
 import torch
 from clarifai.runners.models.model_runner import ModelRunner
+from clarifai.runners.utils.loader import HuggingFaceLoader
 from clarifai.utils.logging import logger
 from clarifai_grpc.grpc.api import resources_pb2, service_pb2
 from clarifai_grpc.grpc.api.status import status_code_pb2
@@ -12,12 +14,69 @@ from PIL import Image
 from transformers import DetrForObjectDetection, DetrImageProcessor
 
 
-def preprocess_image(image_url=None, image_base64=None):
-  if image_base64:
-    img = Image.open(BytesIO(image_base64))
-  elif image_url:
-    img = Image.open(BytesIO(requests.get(image_url).content))
-  return img
+def preprocess_image(image_bytes):
+  """Fetch and preprocess image data from bytes"""
+  return Image.open(BytesIO(image_bytes)).convert("RGB")
+
+
+def video_to_frames(video_bytes):
+  """Convert video bytes to frames"""
+  # Write video bytes to a temporary file
+  with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as temp_video_file:
+    temp_video_file.write(video_bytes)
+    temp_video_path = temp_video_file.name
+    logger.info(f"temp_video_path: {temp_video_path}")
+
+    video = cv2.VideoCapture(temp_video_path)
+    print("video opened")
+    logger.info(f"video opened: {video.isOpened()}")
+    while video.isOpened():
+      ret, frame = video.read()
+      if not ret:
+        break
+      # Convert the frame to byte format
+      frame_bytes = cv2.imencode('.jpg', frame)[1].tobytes()
+      yield frame_bytes
+    video.release()
+
+
+def detect_objects(images, model, processor, device):
+  model_inputs = processor(images=images, return_tensors="pt").to(device)
+  model_inputs = {name: tensor.to(device) for name, tensor in model_inputs.items()}
+  model_output = model(**model_inputs)
+  results = processor.post_process_object_detection(model_output)
+  return results
+
+
+def process_bounding_boxes(results, images, id2label, threshold):
+  outputs = []
+  for i, result in enumerate(results):
+    image = images[i]
+    width, height = image.size
+    output_regions = []
+    for score, label_idx, box in zip(result["scores"], result["labels"], result["boxes"]):
+      if score > threshold:
+        ymin, xmin, ymax, xmax = box
+        xmin, ymin, xmax, ymax = xmin * width, ymin * height, xmax * width, ymax * height
+        output_region = resources_pb2.Region(region_info=resources_pb2.RegionInfo(
+            bounding_box=resources_pb2.BoundingBox(
+                top_row=ymin,
+                left_col=xmin,
+                bottom_row=ymax,
+                right_col=xmax,
+            ),))
+        output_region.data.concepts.append(
+            resources_pb2.Concept(
+                id=str(label_idx.item()),
+                name=id2label[str(label_idx.item())],
+                value=score,
+            ))
+        output_regions.append(output_region)
+    output = resources_pb2.Output()
+    output.data.regions.extend(output_regions)
+    output.status.code = status_code_pb2.SUCCESS
+    outputs.append(output)
+  return outputs
 
 
 class MyRunner(ModelRunner):
@@ -34,6 +93,10 @@ class MyRunner(ModelRunner):
     self.model = DetrForObjectDetection.from_pretrained(
         checkpoint_path, revision="no_timm").to(self.device)
     self.processor = DetrImageProcessor.from_pretrained(checkpoint_path, revision="no_timm")
+    self.model.eval()
+    self.id2label = HuggingFaceLoader.fetch_labels(checkpoint_path)
+    self.threshold = 0.7
+
     logger.info("Done loading!")
 
   def predict(self, request: service_pb2.PostModelOutputsRequest
@@ -41,68 +104,68 @@ class MyRunner(ModelRunner):
     """This is the method that will be called when the runner is run. It takes in an input and
     returns an output.
     """
-
-    # Get the concept protos from the model.
-    concept_protos = request.model.model_version.output_info.data.concepts
-
     outputs = []
-    # TODO: parallelize this over inputs in a single request.
-    for inp in request.inputs:
-      output = resources_pb2.Output()
+    images = []
+    for input in request.inputs:
+      input_data = input.data
 
-      data = inp.data
+      image = preprocess_image(image_bytes=input_data.image.base64)
+      images.append(image)
 
-      output_regions = []
-
-      if data.image.base64 != b"":
-        img = preprocess_image(image_base64=data.image.base64)
-      elif data.image.url != "":
-        img = preprocess_image(image_url=data.image.url)
-
-      with torch.no_grad():
-        inputs = self.processor(images=img, return_tensors="pt").to(self.device)
-        model_output = self.model(**inputs)
+    with torch.no_grad():
+      results = detect_objects(images, self.model, self.processor, self.device)
 
       # convert outputs (bounding boxes and class logits) to COCO API
       # let's only keep detections with score > 0.7 (You can set it to any other value)
-      target_sizes = torch.tensor([img.size[::-1]])
-      results = self.processor.post_process_object_detection(
-          model_output, target_sizes=target_sizes, threshold=0.7)[0]
-
-      width, height = img.size
-      for score, label_idx, box in zip(results["scores"], results["labels"], results["boxes"]):
-        # Normalize bounding box
-        x_min, y_min, x_max, y_max = box
-
-        top_row = round(y_min.item() / height, 2)
-        left_col = round(x_min.item() / width, 2)
-        bottom_row = round(y_max.item() / height, 2)
-        right_col = round(x_max.item() / width, 2)
-
-        output_region = resources_pb2.Region()
-        output_region.id = str(label_idx.item())
-        output_region.value = score.item()
-
-        concept_protos[label_idx.item()].value = score.item()
-        output_region.data.concepts.add(concept_protos[label_idx.item()])
-
-        output_region.region_info.bounding_box.top_row = top_row
-        output_region.region_info.bounding_box.left_col = left_col
-        output_region.region_info.bounding_box.bottom_row = bottom_row
-        output_region.region_info.bounding_box.right_col = right_col
-
-        output_regions.append(output_region)
-
-      output.data.regions.extend(output_regions)
-
-      output.status.code = status_code_pb2.SUCCESS
-      outputs.append(output)
-    return service_pb2.MultiOutputResponse(outputs=outputs,)
+      outputs = process_bounding_boxes(results, images, self.id2label, self.threshold)
+      return service_pb2.MultiOutputResponse(outputs=outputs,)
 
   def generate(self, request: service_pb2.PostModelOutputsRequest
               ) -> Iterator[service_pb2.MultiOutputResponse]:
-    raise NotImplementedError("Stream method is not implemented for image detection models.")
+    if len(request.inputs) != 1:
+      raise ValueError("Only one input is allowed for image classification models.")
+    for input in request.inputs:
+      input_data = input.data
+      if input_data.video.base64:
+        video_bytes = input_data.video.base64
+      elif input_data.image.base64:
+        logger.info("Image input")
+        logger.info(
+            f"len(input_data.image.base64): {len(input_data.image.base64)} start of image: {input_data.image.base64[:10]}"
+        )
+
+        video_bytes = input_data.image.base64
+
+      frame_generator = video_to_frames(video_bytes)
+      for frame in frame_generator:
+        image = preprocess_image(frame)
+        images = [image]
+        with torch.no_grad():
+          results = detect_objects(images, self.model, self.processor, self.device)
+          outputs = process_bounding_boxes(results, images, self.id2label, self.threshold)
+          yield service_pb2.MultiOutputResponse(outputs=outputs,)
 
   def stream(self, request_iterator: Iterator[service_pb2.PostModelOutputsRequest]
             ) -> Iterator[service_pb2.MultiOutputResponse]:
-    raise NotImplementedError("Stream method is not implemented for image detection models.")
+    for request in request_iterator:
+      for output in self.generate(request):
+        yield output
+
+
+if __name__ == '__main__':
+  # Make sure you set these env vars before running the example.
+  # CLARIFAI_PAT
+  # CLARIFAI_USER_ID
+  # CLARIFAI_API_BASE
+  # CLARIFAI_RUNNER_ID
+  # CLARIFAI_NODEPOOL_ID
+  # CLARIFAI_COMPUTE_CLUSTER_ID
+
+  # You need to first create a runner in the Clarifai API and then use the ID here.
+  MyRunner(
+      runner_id=os.environ["CLARIFAI_RUNNER_ID"],
+      nodepool_id=os.environ["CLARIFAI_NODEPOOL_ID"],
+      compute_cluster_id=os.environ["CLARIFAI_COMPUTE_CLUSTER_ID"],
+      base_url=os.environ["CLARIFAI_API_BASE"],
+      num_parallel_polls=int(os.environ.get("CLARIFAI_NUM_THREADS", 1)),
+  ).start()

--- a/models/model_upload/image-detector/detr-resnet-image-detection/requirements.txt
+++ b/models/model_upload/image-detector/detr-resnet-image-detection/requirements.txt
@@ -4,6 +4,6 @@ transformers==4.44.2
 pillow==10.4.0
 requests==2.32.3
 timm==1.0.12
-opencv-python==4.10.0.84
+opencv-python-headless==4.10.0.84
 numpy
 aiohttp

--- a/models/model_upload/image-detector/detr-resnet-image-detection/requirements.txt
+++ b/models/model_upload/image-detector/detr-resnet-image-detection/requirements.txt
@@ -3,3 +3,7 @@ tokenizers==0.19.1
 transformers==4.44.2
 pillow==10.4.0
 requests==2.32.3
+timm==1.0.12
+opencv-python==4.10.0.84
+numpy
+aiohttp


### PR DESCRIPTION
### What
- Implemented stream generation of the output bounding boxes and label concepts for each frame of video in the `generate` method
- Refract both image classifier Model and Image Detector Model, now the `model.py` code is more readable

#### How
We got the input video in bytes, first split the original video into frame,  Each frame is processed independently, then run the detection/classification on each frame.

### Test
- Tested this model example locally using local dev runner
    - Tested with video prediction and it then generate stream of output bounding boxes and label concepts for each frame of video
    - Tested with image predictions
