### PR TITLE
feat: use openai-compatible instead of openai provider

### DIFF
--- a/nodejs/vercel-ai-sdk/getStreamingResponse.js
+++ b/nodejs/vercel-ai-sdk/getStreamingResponse.js
@@ -1,12 +1,12 @@
-import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { streamText } from "ai";
 
-const openai = createOpenAI({
+const clarifai = createOpenAICompatible({
   baseURL: "https://api.clarifai.com/v2/ext/openai/v1",
   apiKey: process.env.CLARIFAI_PAT,
 });
 
-const model = openai(
+const model = clarifai(
   "https://clarifai.com/openai/chat-completion/models/gpt-4o",
 );
 

--- a/nodejs/vercel-ai-sdk/getTextResponse.js
+++ b/nodejs/vercel-ai-sdk/getTextResponse.js
@@ -1,12 +1,12 @@
-import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText } from "ai";
 
-const openai = createOpenAI({
+const clarifai = createOpenAICompatible({
   baseURL: "https://api.clarifai.com/v2/ext/openai/v1",
   apiKey: process.env.CLARIFAI_PAT,
 });
 
-const model = openai(
+const model = clarifai(
   "https://clarifai.com/openai/chat-completion/models/gpt-4o",
 );
 

--- a/nodejs/vercel-ai-sdk/package.json
+++ b/nodejs/vercel-ai-sdk/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -10,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@ai-sdk/openai": "^1.3.22",
+    "@ai-sdk/openai-compatible": "^0.2.14",
     "ai": "^4.3.16",
     "zod": "^3.25.42"
   }


### PR DESCRIPTION
This pull request updates the `nodejs/vercel-ai-sdk` to switch from using the `@ai-sdk/openai` library to the `@ai-sdk/openai-compatible` library for compatibility with Clarifai's API. Additionally, it updates the `package.json` file to set the module type to "ESM."

### Migration to `@ai-sdk/openai-compatible`:

* [`nodejs/vercel-ai-sdk/getStreamingResponse.js`](diffhunk://#diff-6b450c3feeacd70fdcb734cd727813b53b8755e4bc682176a081189386a295f8L1-R9): Replaced `createOpenAI` with `createOpenAICompatible` to use Clarifai's API for streaming responses. Updated the base URL and API key configuration accordingly.
* [`nodejs/vercel-ai-sdk/getTextResponse.js`](diffhunk://#diff-398287c872493e570d715e09ad223602a93e14e4d224b539be7e0e8d0504bf29L1-R9): Replaced `createOpenAI` with `createOpenAICompatible` to use Clarifai's API for text generation. Updated the base URL and API key configuration accordingly.

### Dependency and configuration updates:

* [`nodejs/vercel-ai-sdk/package.json`](diffhunk://#diff-033c498746777118cf14591613aa944fa899249ff011b2208af4b67df3e274e5R6-R14): Replaced the `@ai-sdk/openai` dependency with `@ai-sdk/openai-compatible`. Added `"type": "module"` to enable ES module syntax.