### PR TITLE
fix: truncate multifolder detection input ID to comply with 48-char limit

### DIFF
--- a/datasets/upload/image_detection/multifolder/dataset.py
+++ b/datasets/upload/image_detection/multifolder/dataset.py
@@ -69,7 +69,7 @@ class MultiFolderDetectionDataLoader(ClarifaiDataLoader):
     image_filename = os.path.basename(image_path)
     id_str = os.path.splitext(image_filename)[0].replace(' ', '_').replace('-', '_')
     id_str = ''.join(ch if ch.isalnum() or ch in {'-', '_'} else '_' for ch in id_str)
-    id_str = id_str.strip('_')
+    id_str = id_str.strip('_')[:16]
 
     return VisualDetectionFeatures(image_path, concept_ids, annots, id=id_str)
 


### PR DESCRIPTION
## Summary

- The `MultiFolderDetectionDataLoader` generates input IDs from image filenames (32-char MD5 hashes)
- The Clarifai SDK prepends `<dataset_id>-` to each input ID before uploading, pushing the total length beyond the 48-character API limit
- All 15 inputs were failing with `INPUT_INVALID_REQUEST: id must be between 1 and 48 characters long`
- Fix: truncate `id_str` to 16 characters, keeping the final ID well within the 48-char limit for any reasonable dataset ID name

## Test plan

- [ ] Run dataset upload with a dataset ID of any typical length (e.g. `detection_dataset`)
- [ ] Confirm all inputs upload successfully with no `INPUT_INVALID_REQUEST` errors
- [ ] Verify the upload summary shows 100% inputs and annotations progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)